### PR TITLE
fix: make deployable by modal again

### DIFF
--- a/model.py
+++ b/model.py
@@ -23,6 +23,7 @@ tortoise_image = (
         "torchvision",
         "torchaudio",
         "pydub",
+        "transformers==4.29.2",
         extra_index_url="https://download.pytorch.org/whl/cu116",
     )
     .pip_install("git+https://github.com/metavoicexyz/tortoise-tts")


### PR DESCRIPTION
the original tortoise-tts package had issues with the transformers version, which wasn't pinned. https://github.com/neonbjb/tortoise-tts/pull/508